### PR TITLE
fix(frontend): anti-alias the mic worklet before decimation

### DIFF
--- a/custom_components/voip_stack/frontend/voip-stack-processor.js
+++ b/custom_components/voip_stack/frontend/voip-stack-processor.js
@@ -1,6 +1,38 @@
 const PCM_FORMATS = Object.freeze(["s16le", "s24le", "s24le_in_s32", "s32le"]);
 const FRAME_MS = Object.freeze([10, 16, 20, 32]);
 const TX_BUFFER_POOL = 4;
+// 4th-order Butterworth (2 cascaded biquads) Q values -- used to band-limit
+// the mic signal below the target rate's Nyquist before the linear-
+// interpolation decimation below, which otherwise aliases high-frequency
+// content back into the passband as audible noise.
+const ANTI_ALIAS_Q = Object.freeze([0.54119610, 1.30656296]);
+
+class Biquad {
+  constructor(sampleRateHz, cutoffHz, q) {
+    const omega = (2 * Math.PI * cutoffHz) / sampleRateHz;
+    const alpha = Math.sin(omega) / (2 * q);
+    const cosw = Math.cos(omega);
+    const a0 = 1 + alpha;
+    this._b0 = (1 - cosw) / 2 / a0;
+    this._b1 = (1 - cosw) / a0;
+    this._b2 = this._b0;
+    this._a1 = (-2 * cosw) / a0;
+    this._a2 = (1 - alpha) / a0;
+    this._x1 = 0;
+    this._x2 = 0;
+    this._y1 = 0;
+    this._y2 = 0;
+  }
+
+  process(x0) {
+    const y0 = this._b0 * x0 + this._b1 * this._x1 + this._b2 * this._x2 - this._a1 * this._y1 - this._a2 * this._y2;
+    this._x2 = this._x1;
+    this._x1 = x0;
+    this._y2 = this._y1;
+    this._y1 = y0;
+    return y0;
+  }
+}
 
 function normaliseFormat(value) {
   if (!value) throw new Error("recorder worklet requires negotiated PCM format");
@@ -39,6 +71,25 @@ class RecorderProcessor extends AudioWorkletProcessor {
     this._writeSample = 0;
     this._position = 0;
     this._lastSample = 0;
+
+    this._ratio = sampleRate / this._format.sampleRate;
+    this._antiAliasStages =
+      this._ratio > 1
+        ? ANTI_ALIAS_Q.map((q) => new Biquad(sampleRate, 0.9 * (this._format.sampleRate / 2), q))
+        : null;
+    this._filterScratch = null;
+  }
+
+  _filterBlock(input) {
+    if (!this._filterScratch || this._filterScratch.length !== input.length) {
+      this._filterScratch = new Float32Array(input.length);
+    }
+    for (let i = 0; i < input.length; i++) {
+      let s = input[i];
+      for (const stage of this._antiAliasStages) s = stage.process(s);
+      this._filterScratch[i] = s;
+    }
+    return this._filterScratch;
   }
 
   _encode(sample, sampleIndex) {
@@ -77,20 +128,20 @@ class RecorderProcessor extends AudioWorkletProcessor {
     const input = inputList?.[0]?.[0];
     if (!input?.length) return true;
 
-    const ratio = sampleRate / this._format.sampleRate;
-    if (ratio === 1) {
+    if (this._ratio === 1) {
       for (let i = 0; i < input.length; i++) this._writeMono(input[i]);
     } else {
-      while (this._position < input.length) {
+      const src = this._antiAliasStages ? this._filterBlock(input) : input;
+      while (this._position < src.length) {
         const idx = Math.floor(this._position);
         const frac = this._position - idx;
-        const a = idx > 0 ? input[idx - 1] : this._lastSample;
-        const b = input[idx] ?? a;
+        const a = idx > 0 ? src[idx - 1] : this._lastSample;
+        const b = src[idx] ?? a;
         this._writeMono(a + (b - a) * frac);
-        this._position += ratio;
+        this._position += this._ratio;
       }
-      this._position -= input.length;
-      this._lastSample = input[input.length - 1] || this._lastSample;
+      this._position -= src.length;
+      this._lastSample = src[src.length - 1] || this._lastSample;
     }
     return true;
   }


### PR DESCRIPTION
## Summary

`custom_components/voip_stack/frontend/voip-stack-processor.js` (the mic-capture `AudioWorkletProcessor`) downsamples the browser's native `AudioContext` rate (typically ~48 kHz) to the negotiated PCM format — e.g. 16 kHz for a conference/ring-group leg — using plain linear interpolation with no band-limiting. That aliases high-frequency mic content back into the passband as audible noise/distortion.

The HA-side bridge has handled this correctly since 2026.7.0: `audio_pcm.py`'s `PcmFrameConverter` explicitly documents "a stateful anti-aliased rational resampler so downsampling does not fold content above the destination Nyquist frequency back into the audible band" (Kaiser-windowed polyphase, see module docstring). The browser worklet never got the equivalent treatment, so the anti-aliasing guarantee the project already makes server-side doesn't hold on the client's mic path.

## Confirmation on real hardware

- ESP-to-ESP calls (which never touch this JS worklet) were already clean.
- Calls answered from a browser/Companion App and bridged into a ring-group/conference leg (forced to 16 kHz) were noisy specifically on the receiving end (ESP speaker / other SIP peer) — consistent with mic-side aliasing from the 48kHz→16kHz decimation.
- After this fix, both symptoms went away in a live test (ESP32-S3, dual I2S bus, no codec).

## Fix

Add a 4th-order Butterworth low-pass (two cascaded biquads, standard Q values 0.5412 / 1.3066) ahead of the existing linear-interpolation decimation, cutoff set just under the target rate's Nyquist (`0.9 * targetRate / 2`). Only engaged when downsampling (`ratio > 1`); upsampling is untouched since it doesn't introduce aliasing the same way, and the playback worklet (`voip-stack-playback-processor.js`, always upsampling RX audio) wasn't touched for the same reason.

No changes to the negotiated format contract, buffer pooling, or `postMessage` protocol — this is contained entirely inside `RecorderProcessor`.

## Test plan

- [x] Live ESP32-S3 (no-codec, dual I2S bus) hardware: ESP-to-ESP call unaffected (already clean)
- [x] Live hardware: Companion App answering a doorbell ring-group call — noise/distortion on the ESP speaker resolved
- [ ] Would appreciate a maintainer/CI check on a codec-backed board (ES8311/etc.) if available, though this worklet path is codec-agnostic (pure browser-side JS, no ESP-side involvement)
